### PR TITLE
Potential memory leak in `ensure_column_capacity` due to unsafe realloc usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,60 @@
+
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# debug information files
+*.dwo
+
+# ignored files
+build/*
+test/*

--- a/cupdlpx/io.c
+++ b/cupdlpx/io.c
@@ -359,14 +359,25 @@ static bool ensure_column_capacity(MpsParserState *state)
 
     size_t new_cap = (state->col_capacity == 0) ? 256 : state->col_capacity * 2;
 
-    state->objective_coeffs = (double *)realloc(state->objective_coeffs, new_cap * sizeof(double));
-    state->var_lower_bounds = (double *)realloc(state->var_lower_bounds, new_cap * sizeof(double));
-    state->var_upper_bounds = (double *)realloc(state->var_upper_bounds, new_cap * sizeof(double));
-
-    if (!state->objective_coeffs || !state->var_lower_bounds || !state->var_upper_bounds)
+    if (new_cap < state->col_capacity)
     {
         return false;
     }
+
+    double *new_obj = realloc(state->objective_coeffs, new_cap * sizeof(double));
+    double *new_lb  = realloc(state->var_lower_bounds, new_cap * sizeof(double));
+    double *new_ub  = realloc(state->var_upper_bounds, new_cap * sizeof(double));
+
+    if (!new_obj || !new_lb || !new_ub) {
+        if (new_obj && new_obj != state->objective_coeffs) free(new_obj);
+        if (new_lb  && new_lb  != state->var_lower_bounds) free(new_lb);
+        if (new_ub  && new_ub  != state->var_upper_bounds) free(new_ub);
+        return false;
+    }
+
+    state->objective_coeffs = new_obj;
+    state->var_lower_bounds = new_lb;
+    state->var_upper_bounds = new_ub;
 
     for (size_t i = state->col_capacity; i < new_cap; ++i)
     {

--- a/cupdlpx/io.c
+++ b/cupdlpx/io.c
@@ -336,11 +336,9 @@ static int add_coo_entry(CooMatrix *coo, int row, int col, double value)
     if (coo->nnz >= coo->capacity)
     {
         size_t new_capacity = (coo->capacity == 0) ? 1024 : coo->capacity * 2;
-        coo->row_indices = (int *)realloc(coo->row_indices, new_capacity * sizeof(int));
-        coo->col_indices = (int *)realloc(coo->col_indices, new_capacity * sizeof(int));
-        coo->values = (double *)realloc(coo->values, new_capacity * sizeof(double));
-        if (!coo->row_indices || !coo->col_indices || !coo->values)
-            return -1;
+        coo->row_indices = (int *)safe_realloc(coo->row_indices, new_capacity * sizeof(int));
+        coo->col_indices = (int *)safe_realloc(coo->col_indices, new_capacity * sizeof(int));
+        coo->values = (double *)safe_realloc(coo->values, new_capacity * sizeof(double));
         coo->capacity = new_capacity;
     }
     coo->row_indices[coo->nnz] = row;
@@ -364,20 +362,9 @@ static bool ensure_column_capacity(MpsParserState *state)
         return false;
     }
 
-    double *new_obj = realloc(state->objective_coeffs, new_cap * sizeof(double));
-    double *new_lb  = realloc(state->var_lower_bounds, new_cap * sizeof(double));
-    double *new_ub  = realloc(state->var_upper_bounds, new_cap * sizeof(double));
-
-    if (!new_obj || !new_lb || !new_ub) {
-        if (new_obj && new_obj != state->objective_coeffs) free(new_obj);
-        if (new_lb  && new_lb  != state->var_lower_bounds) free(new_lb);
-        if (new_ub  && new_ub  != state->var_upper_bounds) free(new_ub);
-        return false;
-    }
-
-    state->objective_coeffs = new_obj;
-    state->var_lower_bounds = new_lb;
-    state->var_upper_bounds = new_ub;
+    state->objective_coeffs = (double *)safe_realloc(state->objective_coeffs, new_cap * sizeof(double));
+    state->var_lower_bounds = (double *)safe_realloc(state->var_lower_bounds, new_cap * sizeof(double));
+    state->var_upper_bounds = (double *)safe_realloc(state->var_upper_bounds, new_cap * sizeof(double));
 
     for (size_t i = state->col_capacity; i < new_cap; ++i)
     {
@@ -575,9 +562,7 @@ static int parse_rows_section(MpsParserState *state, char **tokens, int n_tokens
     if (state->num_buffered_rows >= state->buffered_rows_capacity)
     {
         state->buffered_rows_capacity = (state->buffered_rows_capacity == 0) ? 64 : state->buffered_rows_capacity * 2;
-        state->buffered_rows = (BufferedRow *)realloc(state->buffered_rows, state->buffered_rows_capacity * sizeof(BufferedRow));
-        if (!state->buffered_rows)
-            return -1;
+        state->buffered_rows = (BufferedRow *)safe_realloc(state->buffered_rows, state->buffered_rows_capacity * sizeof(BufferedRow));
     }
 
     BufferedRow *new_row = &state->buffered_rows[state->num_buffered_rows];
@@ -627,9 +612,7 @@ static int finalize_rows(MpsParserState *state)
             if (current_size >= state->constraint_capacity)
             {
                 state->constraint_capacity = (state->constraint_capacity == 0) ? 64 : state->constraint_capacity * 2;
-                state->constraint_types = (char *)realloc(state->constraint_types, state->constraint_capacity * sizeof(char));
-                if (!state->constraint_types)
-                    return -1;
+                state->constraint_types = (char *)safe_realloc(state->constraint_types, state->constraint_capacity * sizeof(char));
             }
             namemap_put(&state->row_map, state->buffered_rows[i].name);
             state->constraint_types[current_size] = type;

--- a/cupdlpx/utils.cu
+++ b/cupdlpx/utils.cu
@@ -27,7 +27,7 @@ std::normal_distribution<double> dist(0.0, 1.0);
 const double HOST_ONE = 1.0;
 const double HOST_ZERO = 0.0;
 
-void *safe_malloc(int size)
+void *safe_malloc(size_t size)
 {
     void *ptr = malloc(size);
     if (ptr == NULL)
@@ -38,7 +38,7 @@ void *safe_malloc(int size)
     return ptr;
 }
 
-void *safe_calloc(int num, int size)
+void *safe_calloc(size_t num, size_t size)
 {
     void *ptr = calloc(num, size);
     if (ptr == NULL)
@@ -47,6 +47,20 @@ void *safe_calloc(int num, int size)
         exit(EXIT_FAILURE);
     }
     return ptr;
+}
+
+void *safe_realloc(void *ptr, size_t new_size)
+{
+    if (new_size == 0) {
+        free(ptr);
+        return NULL;
+    }
+    void *tmp = realloc(ptr, new_size);
+    if (!tmp) {
+        perror("Fatal error: realloc failed");
+        exit(EXIT_FAILURE);
+    }
+    return tmp;
 }
 
 double estimate_maximum_singular_value(

--- a/cupdlpx/utils.h
+++ b/cupdlpx/utils.h
@@ -67,9 +67,12 @@ extern "C"
     extern const double HOST_ONE;
     extern const double HOST_ZERO;
 
-    void *safe_malloc(int size);
+    void *safe_malloc(size_t size);
+    
+    void *safe_calloc(size_t num, size_t size);
 
-    void *safe_calloc(int num, int size);
+    void *safe_realloc(void *ptr, size_t new_size);
+
 
     double estimate_maximum_singular_value(
         cusparseHandle_t sparse_handle,


### PR DESCRIPTION
### Summary

I found a potential memory leak in `ensure_column_capacity` when handling `realloc` failures.

### Root cause
In the current implementation, the results of `realloc` are assigned directly to `state->objective_coeffs`, `state->var_lower_bounds`, and `state->var_upper_bounds`. If one `realloc` succeeds but a later one fails, the original pointer is lost,
causing a memory leak.

### Suggested fix
Use temporary variables for each `realloc` call, only assign back if all succeed, and free any partially allocated blocks on failure. I implemented a fix in my fork.

### Impact
No functional change in normal cases. The fix only improves robustness in low-memory conditions by preventing leaks.

### Testing
Pass the test with `2club200v15p5scn.mps.gz` instance.