### PR TITLE
Fix two bugs: final solution rescaling and num of variable

### DIFF
--- a/cupdlpx/solver.h
+++ b/cupdlpx/solver.h
@@ -28,11 +28,11 @@ extern "C"
 {
 #endif
 
-    pdhg_solver_state_t *optimize(
+    cupdlpx_result_t *optimize(
         const pdhg_parameters_t *params,
         const lp_problem_t *original_problem);
 
-    void pdhg_solver_state_free(pdhg_solver_state_t *state);
+    void cupdlpx_result_free(cupdlpx_result_t *results);
 
 #ifdef __cplusplus
 }

--- a/cupdlpx/struct.h
+++ b/cupdlpx/struct.h
@@ -150,8 +150,6 @@ typedef struct
 	double *primal_slack;
 	double *dual_slack;
 	double rescaling_time_sec;
-	double gpu_to_cpu_time_sec;
-	double basic_time_sec;
 	double cumulative_time_sec;
 
 	double *primal_residual;
@@ -196,3 +194,31 @@ typedef struct
 	double *ones_primal_d;
 	double *ones_dual_d;
 } pdhg_solver_state_t;
+
+typedef struct
+{
+	int num_variables;
+	int num_constraints;
+
+	double *primal_solution;
+	double *dual_solution;
+	
+	int total_count;
+	double rescaling_time_sec;
+	double cumulative_time_sec;
+
+	double absolute_primal_residual;
+	double relative_primal_residual;
+	double absolute_dual_residual;
+	double relative_dual_residual;
+	double primal_objective_value;
+	double dual_objective_value;
+	double objective_gap;
+	double relative_objective_gap;
+	double max_primal_ray_infeasibility;
+	double max_dual_ray_infeasibility;
+	double primal_ray_linear_objective;
+	double dual_ray_objective;
+	termination_reason_t termination_reason;
+
+} cupdlpx_result_t;


### PR DESCRIPTION
This PR fixes two bugs to ensure the solver's output is correct.

### 1. Final Solution Rescaling
-   **Problem:** The solver was returning a solution for the scaled internal problem, not the original one.
-   **Fix:** The final solution is now correctly scaled back to match the original problem. The `optimize()` function now also returns a clean `cupdlpx_result_t` struct instead of the internal solver state.

### 2. Variable Count in MPS Parser
-   **Problem:** The parser was counting one more variable for mixed-integer MPS files.
-   **Fix:** This happened because it mistakenly treated integer marker lines (like `'MARKER' 'INTORG'`) as new variables. The parser is now fixed to ignore these lines, so the variable count is correct.