### PR TITLE
Feat: Support all GPU architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,7 @@ endif()
 set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
-# Optional: choose CUDA architectures (adjust as needed)
-# e.g., 80=Ampere A100, 86=RTX30, 89=Hopper H100 (SM90=90)
-set(CMAKE_CUDA_ARCHITECTURES 75;80;86;89;90;90-virtual)
+set(CMAKE_CUDA_ARCHITECTURES "all")
 
 set(PYBIND11_FINDPYTHON ON)
 find_package(pybind11 CONFIG REQUIRED)

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,9 @@ BUILD_DIR = ./build
 CFLAGS = -I. -I$(CUDA_HOME)/include -fPIC -O3 -Wall -Wextra -g
 
 # NVCCFLAGS for CUDA compiler (nvcc)
+GPU_ARCH := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1 | sed 's/\.//')
 NVCCFLAGS = -I. -I$(CUDA_HOME)/include -O3 -g \
-            -gencode arch=compute_75,code=sm_75 \
-	          -gencode arch=compute_80,code=sm_80 \
-            -gencode arch=compute_86,code=sm_86 \
-            -gencode arch=compute_80,code=sm_89 \
-            -gencode arch=compute_90,code=sm_90 \
+            -gencode arch=compute_$(GPU_ARCH),code=sm_$(GPU_ARCH) \
             -Xcompiler -fPIC  -Xcompiler -gdwarf-4 -ccbin $(SYSTEM_GXX)
 
 # LDFLAGS for the linker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "cupdlpx"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python bindings for cuPDLPx (GPU-accelerated first-order LP solver)"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
# Fixes #14 

This PR updates the build system to support all NVIDIA GPUs by default.

1. Sets `CMAKE_CUDA_ARCHITECTURES` to "all" in `CMakeLists.txt`.
2. Updates the `Makefile` to match.
3. Bumps version to `0.1.2`.

This makes the project easier to build on different machines, though compile times may increase.

