### PR TITLE
New Feature: Feasibility Polishing

### DIFF
--- a/include/cupdlpx_types.h
+++ b/include/cupdlpx_types.h
@@ -31,7 +31,8 @@ extern "C"
 		TERMINATION_REASON_PRIMAL_INFEASIBLE,
 		TERMINATION_REASON_DUAL_INFEASIBLE,
 		TERMINATION_REASON_TIME_LIMIT,
-		TERMINATION_REASON_ITERATION_LIMIT
+		TERMINATION_REASON_ITERATION_LIMIT,
+		TERMINATION_REASON_FEAS_POLISH_SUCCESS
 	} termination_reason_t;
 
 	typedef struct
@@ -70,6 +71,7 @@ extern "C"
 	{
 		double eps_optimal_relative;
 		double eps_feasible_relative;
+		double eps_feas_polish_relative;
 		double eps_infeasible;
 		double time_sec_limit;
 		int iteration_limit;
@@ -86,6 +88,7 @@ extern "C"
 		termination_criteria_t termination_criteria;
 		restart_parameters_t restart_params;
 		double reflection_coefficient;
+		bool feasibility_polishing;
 	} pdhg_parameters_t;
 
 	typedef struct
@@ -113,7 +116,8 @@ extern "C"
 		double primal_ray_linear_objective;
 		double dual_ray_objective;
 		termination_reason_t termination_reason;
-
+		double feasibility_polishing_time;
+		int feasibility_iteration;
 	} cupdlpx_result_t;
 
 	// matrix formats

--- a/internal/internal_types.h
+++ b/internal/internal_types.h
@@ -122,6 +122,9 @@ typedef struct
 
 	double *ones_primal_d;
 	double *ones_dual_d;
+
+	double feasibility_polishing_time;
+	int feasibility_iteration;
 } pdhg_solver_state_t;
 
 typedef struct

--- a/internal/utils.h
+++ b/internal/utils.h
@@ -125,6 +125,21 @@ extern "C"
     int coo_to_csr(const matrix_desc_t *desc,
                    int **row_ptr, int **col_ind, double **vals, int *nnz_out);
 
+    void check_feas_polishing_termination_criteria(
+        pdhg_solver_state_t *solver_state,
+        const termination_criteria_t *criteria,
+        bool is_primal_polish);
+
+    void print_initial_feas_polish_info(bool is_primal_polish, const pdhg_parameters_t *params);
+
+    void display_feas_polish_iteration_stats(const pdhg_solver_state_t *state, bool verbose,  bool is_primal_polish);
+
+    void pdhg_feas_polish_final_log(const pdhg_solver_state_t *primal_state, const pdhg_solver_state_t *dual_state, bool verbose);
+
+    void compute_primal_feas_polish_residual(pdhg_solver_state_t *state, const pdhg_solver_state_t *ori_state);
+
+    void compute_dual_feas_polish_residual(pdhg_solver_state_t *state, const pdhg_solver_state_t *ori_state);
+
 #ifdef __cplusplus
 }
 

--- a/src/solver.cu
+++ b/src/solver.cu
@@ -75,9 +75,23 @@ static pdhg_solver_state_t *
 initialize_solver_state(const lp_problem_t *original_problem,
                         const rescale_info_t *rescale_info);
 static void compute_fixed_point_error(pdhg_solver_state_t *state);
-void lp_problem_free(lp_problem_t *prob);
 void pdhg_solver_state_free(pdhg_solver_state_t *state);
 void rescale_info_free(rescale_info_t *info);
+
+static void perform_primal_restart(pdhg_solver_state_t *state);    
+static void perform_dual_restart(pdhg_solver_state_t *state);
+void primal_feasibility_polish(const pdhg_parameters_t *params, pdhg_solver_state_t *state, const pdhg_solver_state_t *ori_state);
+void dual_feasibility_polish(const pdhg_parameters_t *params, pdhg_solver_state_t *state, const pdhg_solver_state_t *ori_state);
+void primal_feas_polish_state_free(pdhg_solver_state_t *state);
+void dual_feas_polish_state_free(pdhg_solver_state_t *state);
+void feasibility_polish(const pdhg_parameters_t *params, pdhg_solver_state_t *state);
+static void compute_primal_fixed_point_error(pdhg_solver_state_t *state);
+static void compute_dual_fixed_point_error(pdhg_solver_state_t *state);
+static pdhg_solver_state_t *initialize_primal_feas_polish_state(
+    const pdhg_solver_state_t *original_state);
+static pdhg_solver_state_t *initialize_dual_feas_polish_state(
+    const pdhg_solver_state_t *original_state);
+
 
 cupdlpx_result_t *optimize(const pdhg_parameters_t *params,
                            const lp_problem_t *original_problem)
@@ -142,6 +156,14 @@ cupdlpx_result_t *optimize(const pdhg_parameters_t *params,
     }
 
     pdhg_final_log(state, params->verbose, state->termination_reason);
+
+    if (params->feasibility_polishing && 
+        state->termination_reason != TERMINATION_REASON_DUAL_INFEASIBLE && 
+        state->termination_reason != TERMINATION_REASON_PRIMAL_INFEASIBLE)
+    {
+        feasibility_polish(params, state);
+    }
+
     cupdlpx_result_t *results = create_result_from_state(state);
     pdhg_solver_state_free(state);
     return results;
@@ -924,6 +946,8 @@ static cupdlpx_result_t *create_result_from_state(pdhg_solver_state_t *state)
     results->primal_ray_linear_objective = state->primal_ray_linear_objective;
     results->dual_ray_objective = state->dual_ray_objective;
     results->termination_reason = state->termination_reason;
+    results->feasibility_polishing_time = state->feasibility_polishing_time;
+    results->feasibility_iteration = state->feasibility_iteration;
 
     return results;
 }
@@ -943,6 +967,7 @@ void set_default_parameters(pdhg_parameters_t *params)
     params->termination_criteria.eps_infeasible = 1e-10;
     params->termination_criteria.time_sec_limit = 3600.0;
     params->termination_criteria.iteration_limit = INT32_MAX;
+    params->termination_criteria.eps_feas_polish_relative = 1e-6;
 
     params->restart_params.artificial_restart_threshold = 0.36;
     params->restart_params.sufficient_reduction_for_restart = 0.2;
@@ -952,3 +977,466 @@ void set_default_parameters(pdhg_parameters_t *params)
     params->restart_params.k_d = 0.0;
     params->restart_params.i_smooth = 0.3;
 }
+
+//Feasibility Polishing
+void feasibility_polish(const pdhg_parameters_t *params, pdhg_solver_state_t *state)
+{
+    clock_t start_time = clock();
+    if (state->relative_primal_residual < params->termination_criteria.eps_feas_polish_relative &&
+        state->relative_dual_residual < params->termination_criteria.eps_feas_polish_relative)
+    {
+        
+        printf("Skipping feasibility polishing as the solution is already sufficiently feasible.\n");
+        return;
+    }
+    double original_primal_weight = 0.0;
+    if (params->bound_objective_rescaling)
+    {
+        original_primal_weight = 1.0;
+    }
+    else
+    {
+        original_primal_weight = (state->objective_vector_norm + 1.0) / (state->constraint_bound_norm + 1.0);
+    }
+
+    //PRIMAL FEASIBILITY POLISHING
+    pdhg_solver_state_t *primal_state = initialize_primal_feas_polish_state(state);
+    primal_state->primal_weight = original_primal_weight;
+    primal_state->best_primal_weight = original_primal_weight;
+    primal_feasibility_polish(params, primal_state, state);
+
+    if (primal_state->termination_reason == TERMINATION_REASON_FEAS_POLISH_SUCCESS)
+    {
+        CUDA_CHECK(cudaMemcpy(
+            state->pdhg_primal_solution, primal_state->pdhg_primal_solution,
+            state->num_variables * sizeof(double), cudaMemcpyDeviceToDevice));
+        state->absolute_primal_residual = primal_state->absolute_primal_residual;
+        state->relative_primal_residual = primal_state->relative_primal_residual;
+        state->primal_objective_value = primal_state->primal_objective_value;
+    }
+    state->feasibility_iteration += primal_state->total_count - 1;
+    
+    //DUAL FEASIBILITY POLISHING
+    pdhg_solver_state_t *dual_state = initialize_dual_feas_polish_state(state);
+    dual_state->primal_weight = original_primal_weight;
+    dual_state->best_primal_weight = original_primal_weight;
+    dual_feasibility_polish(params, dual_state, state);
+
+    if (dual_state->termination_reason == TERMINATION_REASON_FEAS_POLISH_SUCCESS)
+    {
+        CUDA_CHECK(cudaMemcpy(
+            state->pdhg_dual_solution, dual_state->pdhg_dual_solution,
+            state->num_constraints * sizeof(double), cudaMemcpyDeviceToDevice));
+        state->absolute_dual_residual = dual_state->absolute_dual_residual;
+        state->relative_dual_residual = dual_state->relative_dual_residual;
+        state->dual_objective_value = dual_state->dual_objective_value;
+    }
+    state->feasibility_iteration += dual_state->total_count - 1;
+
+    state->objective_gap = fabs(state->primal_objective_value - state->dual_objective_value);
+    state->relative_objective_gap = state->objective_gap / (1.0 + fabs(state->primal_objective_value) + fabs(state->dual_objective_value));
+    
+    // FINAL LOGGING
+    pdhg_feas_polish_final_log(primal_state, dual_state, params->verbose);
+    primal_feas_polish_state_free(primal_state);
+    dual_feas_polish_state_free(dual_state);
+
+    state->feasibility_polishing_time = (double)(clock() - start_time) / CLOCKS_PER_SEC;
+    return;
+}
+
+void primal_feasibility_polish(const pdhg_parameters_t *params, pdhg_solver_state_t *state, const pdhg_solver_state_t *ori_state)
+{
+    print_initial_feas_polish_info(true, params);
+    clock_t start_time = clock();
+    bool do_restart = false;
+    while (state->termination_reason == TERMINATION_REASON_UNSPECIFIED)
+    {
+        if ((state->is_this_major_iteration || state->total_count == 0) || (state->total_count % get_print_frequency(state->total_count) == 0))
+        {
+            compute_primal_feas_polish_residual(state, ori_state);
+
+            state->cumulative_time_sec = (double)(clock() - start_time) / CLOCKS_PER_SEC;
+
+            check_feas_polishing_termination_criteria(state, &params->termination_criteria, true);
+            display_feas_polish_iteration_stats(state, params->verbose, true);
+        }
+
+        if ((state->is_this_major_iteration || state->total_count == 0))
+        {
+            do_restart = should_do_adaptive_restart(state, &params->restart_params, params->termination_evaluation_frequency);
+            if (do_restart)
+                perform_primal_restart(state);
+        }
+
+        state->is_this_major_iteration = ((state->total_count + 1) % params->termination_evaluation_frequency) == 0;
+
+        compute_next_pdhg_primal_solution(state);
+        compute_next_pdhg_dual_solution(state);
+
+        if (state->is_this_major_iteration || do_restart)
+        {
+            compute_primal_fixed_point_error(state);
+            if (do_restart)
+            {
+                state->initial_fixed_point_error = state->fixed_point_error;
+                do_restart = false;
+            }
+        }
+        halpern_update(state, params->reflection_coefficient);
+
+        state->inner_count++;
+        state->total_count++;
+    }
+    return;
+}
+
+void dual_feasibility_polish(const pdhg_parameters_t *params, pdhg_solver_state_t *state, const pdhg_solver_state_t *ori_state)
+{
+    print_initial_feas_polish_info(false, params);
+    clock_t start_time = clock();
+    bool do_restart = false;
+    while (state->termination_reason == TERMINATION_REASON_UNSPECIFIED)
+    {
+        if ((state->is_this_major_iteration || state->total_count == 0) || (state->total_count % get_print_frequency(state->total_count) == 0))
+        {
+            compute_dual_feas_polish_residual(state, ori_state);
+
+            state->cumulative_time_sec = (double)(clock() - start_time) / CLOCKS_PER_SEC;
+
+            check_feas_polishing_termination_criteria(state, &params->termination_criteria, false);
+            display_feas_polish_iteration_stats(state, params->verbose, false);
+        }
+
+        if ((state->is_this_major_iteration || state->total_count == 0))
+        {
+            do_restart = should_do_adaptive_restart(state, &params->restart_params, params->termination_evaluation_frequency);
+            if (do_restart)
+                perform_dual_restart(state);
+        }
+
+        state->is_this_major_iteration = ((state->total_count + 1) % params->termination_evaluation_frequency) == 0;
+
+        compute_next_pdhg_primal_solution(state);
+        compute_next_pdhg_dual_solution(state);
+
+        if (state->is_this_major_iteration || do_restart)
+        {
+            compute_dual_fixed_point_error(state);
+            if (do_restart)
+            {
+                state->initial_fixed_point_error = state->fixed_point_error;
+                do_restart = false;
+            }
+        }
+        halpern_update(state, params->reflection_coefficient);
+
+        state->inner_count++;
+        state->total_count++;
+    }
+    return;
+}
+
+static pdhg_solver_state_t *initialize_primal_feas_polish_state(
+    const pdhg_solver_state_t *original_state)
+{
+    pdhg_solver_state_t *primal_state = (pdhg_solver_state_t *)malloc(sizeof(pdhg_solver_state_t));
+    *primal_state = *original_state;
+    int num_var = original_state->num_variables;
+    int num_cons = original_state->num_constraints;
+
+#define ALLOC_ZERO(dest, bytes)           \
+    CUDA_CHECK(cudaMalloc(&dest, bytes)); \
+    CUDA_CHECK(cudaMemset(dest, 0, bytes));
+
+    //RESET PROBLEM TO FEASIBILITY PROBLEM
+    ALLOC_ZERO(primal_state->objective_vector, num_var * sizeof(double));
+    primal_state->objective_constant = 0.0;
+
+#define ALLOC_AND_COPY_DEV(dest, src, bytes)  \
+    CUDA_CHECK(cudaMalloc(&dest, bytes)); \
+    CUDA_CHECK(cudaMemcpy(dest, src, bytes, cudaMemcpyDeviceToDevice));
+
+    //ALLOCATE AND COPY SOLUTION VECTORS
+    ALLOC_AND_COPY_DEV(primal_state->initial_primal_solution, original_state->initial_primal_solution, num_var * sizeof(double));
+    ALLOC_AND_COPY_DEV(primal_state->current_primal_solution, original_state->current_primal_solution, num_var * sizeof(double));
+    ALLOC_AND_COPY_DEV(primal_state->pdhg_primal_solution, original_state->pdhg_primal_solution, num_var * sizeof(double));
+    ALLOC_AND_COPY_DEV(primal_state->reflected_primal_solution, original_state->reflected_primal_solution, num_var * sizeof(double));
+    ALLOC_AND_COPY_DEV(primal_state->primal_product, original_state->primal_product, num_cons * sizeof(double));
+
+    //ALLOC ZERO FOR OTHERS
+    ALLOC_ZERO(primal_state->initial_dual_solution, num_cons * sizeof(double));
+    ALLOC_ZERO(primal_state->current_dual_solution, num_cons * sizeof(double));
+    ALLOC_ZERO(primal_state->pdhg_dual_solution, num_cons * sizeof(double));
+    ALLOC_ZERO(primal_state->reflected_dual_solution, num_cons * sizeof(double));
+    ALLOC_ZERO(primal_state->dual_product, num_var * sizeof(double));
+
+    ALLOC_ZERO(primal_state->dual_slack, num_var * sizeof(double));
+    ALLOC_ZERO(primal_state->primal_slack, num_cons * sizeof(double));
+    ALLOC_ZERO(primal_state->dual_residual, num_var * sizeof(double));
+    ALLOC_ZERO(primal_state->primal_residual, num_cons * sizeof(double));
+    ALLOC_ZERO(primal_state->delta_primal_solution, num_var * sizeof(double));
+    ALLOC_ZERO(primal_state->delta_dual_solution, num_cons * sizeof(double));
+
+    //RESET SCALAR
+    primal_state->primal_weight_error_sum = 0.0;
+    primal_state->primal_weight_last_error = 0.0;
+    primal_state->best_primal_weight = 0.0;
+    primal_state->fixed_point_error = INFINITY;
+    primal_state->initial_fixed_point_error = INFINITY;
+    primal_state->last_trial_fixed_point_error = INFINITY;
+    primal_state->step_size = original_state->step_size;
+    primal_state->primal_weight = original_state->primal_weight;
+    primal_state->is_this_major_iteration = false;
+    primal_state->total_count = 0;
+    primal_state->inner_count = 0;
+    primal_state->termination_reason = TERMINATION_REASON_UNSPECIFIED;
+    primal_state->cumulative_time_sec = 0.0;
+    primal_state->best_primal_dual_residual_gap = INFINITY;
+
+    //IGNORE DUAL RESIDUAL AND OBJECTIVE GAP
+    primal_state->relative_dual_residual = 0.0;
+    primal_state->absolute_dual_residual = 0.0;
+    primal_state->relative_objective_gap = 0.0;
+    primal_state->objective_gap = 0.0;
+
+    return primal_state;
+}
+
+void primal_feas_polish_state_free(pdhg_solver_state_t *state)
+{
+    #define SAFE_CUDA_FREE(p)   \
+    if ((p) != NULL) {          \
+        CUDA_CHECK(cudaFree(p));\
+        (p) = NULL;             \
+    }                           \
+    
+    if (!state) return;
+    SAFE_CUDA_FREE(state->objective_vector);
+    SAFE_CUDA_FREE(state->initial_primal_solution);
+    SAFE_CUDA_FREE(state->current_primal_solution);
+    SAFE_CUDA_FREE(state->pdhg_primal_solution);
+    SAFE_CUDA_FREE(state->reflected_primal_solution);
+
+    SAFE_CUDA_FREE(state->dual_product);
+    SAFE_CUDA_FREE(state->initial_dual_solution);
+    SAFE_CUDA_FREE(state->current_dual_solution);
+    SAFE_CUDA_FREE(state->pdhg_dual_solution);
+    SAFE_CUDA_FREE(state->reflected_dual_solution);
+    SAFE_CUDA_FREE(state->primal_product);
+    
+    SAFE_CUDA_FREE(state->primal_slack);
+    SAFE_CUDA_FREE(state->dual_slack);
+    SAFE_CUDA_FREE(state->primal_residual);
+    SAFE_CUDA_FREE(state->dual_residual);
+    SAFE_CUDA_FREE(state->delta_primal_solution);
+    SAFE_CUDA_FREE(state->delta_dual_solution);
+    free(state);
+}
+
+__global__ void zero_finite_value_vectors_kernel(
+    double *__restrict__ vec, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n)
+    {
+        if (isfinite(vec[idx]))
+            vec[idx] = 0.0;
+    }
+}
+    
+
+static pdhg_solver_state_t *initialize_dual_feas_polish_state(
+    const pdhg_solver_state_t *original_state)
+{
+    pdhg_solver_state_t *dual_state = (pdhg_solver_state_t *)malloc(sizeof(pdhg_solver_state_t));
+    *dual_state = *original_state;
+    int num_var = original_state->num_variables;
+    int num_cons = original_state->num_constraints;
+
+    #define ALLOC_AND_COPY_DEV(dest, src, bytes)  \
+        CUDA_CHECK(cudaMalloc(&dest, bytes)); \
+        CUDA_CHECK(cudaMemcpy(dest, src, bytes, cudaMemcpyDeviceToDevice));
+
+    //RESET PROBLEM TO DUAL FEASIBILITY PROBLEM
+    #define SET_FINITE_TO_ZERO(vec, n) \
+        { \
+            int threads = 256; \
+            int blocks = (n + threads - 1) / threads; \
+            zero_finite_value_vectors_kernel<<<blocks, threads>>>(vec, n); \
+            CUDA_CHECK(cudaDeviceSynchronize()); \
+        }
+
+    ALLOC_AND_COPY_DEV(dual_state->constraint_lower_bound, original_state->constraint_lower_bound, num_cons * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->constraint_upper_bound, original_state->constraint_upper_bound, num_cons * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->variable_lower_bound, original_state->variable_lower_bound, num_var * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->variable_upper_bound, original_state->variable_upper_bound, num_var * sizeof(double));
+
+    SET_FINITE_TO_ZERO(dual_state->constraint_lower_bound, num_cons);
+    SET_FINITE_TO_ZERO(dual_state->constraint_upper_bound, num_cons);
+    SET_FINITE_TO_ZERO(dual_state->variable_lower_bound, num_var);
+    SET_FINITE_TO_ZERO(dual_state->variable_upper_bound, num_var);
+
+    #define ALLOC_ZERO(dest, bytes)           \
+        CUDA_CHECK(cudaMalloc(&dest, bytes)); \
+        CUDA_CHECK(cudaMemset(dest, 0, bytes));
+
+    ALLOC_ZERO(dual_state->constraint_lower_bound_finite_val, num_cons * sizeof(double));
+    ALLOC_ZERO(dual_state->constraint_upper_bound_finite_val, num_cons * sizeof(double));
+    ALLOC_ZERO(dual_state->variable_lower_bound_finite_val, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->variable_upper_bound_finite_val, num_var * sizeof(double));
+
+    //ALLOCATE AND COPY SOLUTION VECTORS
+    ALLOC_AND_COPY_DEV(dual_state->initial_dual_solution, original_state->initial_dual_solution, num_cons * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->current_dual_solution, original_state->current_dual_solution, num_cons * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->pdhg_dual_solution, original_state->pdhg_dual_solution, num_cons * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->reflected_dual_solution, original_state->reflected_dual_solution, num_cons * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->dual_product, original_state->dual_product, num_var * sizeof(double));
+    ALLOC_AND_COPY_DEV(dual_state->dual_slack, original_state->dual_slack, num_var * sizeof(double));
+
+    //ALLOC ZERO FOR OTHERS
+    ALLOC_ZERO(dual_state->initial_primal_solution, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->current_primal_solution, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->pdhg_primal_solution, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->reflected_primal_solution, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->primal_product, num_cons * sizeof(double));
+    ALLOC_ZERO(dual_state->primal_slack, num_cons * sizeof(double));
+    ALLOC_ZERO(dual_state->dual_residual, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->primal_residual, num_cons * sizeof(double));
+    ALLOC_ZERO(dual_state->delta_primal_solution, num_var * sizeof(double));
+    ALLOC_ZERO(dual_state->delta_dual_solution, num_cons * sizeof(double));
+
+    //RESET SCALAR
+    dual_state->primal_weight_error_sum = 0.0;
+    dual_state->primal_weight_last_error = 0.0;
+    dual_state->best_primal_weight = 0.0;
+    dual_state->fixed_point_error = INFINITY;
+    dual_state->initial_fixed_point_error = INFINITY;
+    dual_state->last_trial_fixed_point_error = INFINITY;
+    dual_state->step_size = original_state->step_size;
+    dual_state->primal_weight = original_state->primal_weight;
+    dual_state->is_this_major_iteration = false;
+    dual_state->total_count = 0;
+    dual_state->inner_count = 0;
+    dual_state->termination_reason = TERMINATION_REASON_UNSPECIFIED;
+    dual_state->cumulative_time_sec = 0.0;
+    dual_state->best_primal_dual_residual_gap = INFINITY;
+
+    //IGNORE PRIMAL RESIDUAL AND OBJECTIVE GAP
+    dual_state->relative_primal_residual = 0.0;
+    dual_state->absolute_primal_residual = 0.0;
+    dual_state->relative_objective_gap = 0.0;
+    dual_state->objective_gap = 0.0;
+    return dual_state;
+}
+
+void dual_feas_polish_state_free(pdhg_solver_state_t *state)
+{
+    #define SAFE_CUDA_FREE(p)   \
+    if ((p) != NULL) {          \
+        CUDA_CHECK(cudaFree(p));\
+        (p) = NULL;             \
+    }                           \
+    
+    if (!state) return;
+    SAFE_CUDA_FREE(state->constraint_lower_bound);
+    SAFE_CUDA_FREE(state->constraint_upper_bound);
+    SAFE_CUDA_FREE(state->variable_lower_bound);
+    SAFE_CUDA_FREE(state->variable_upper_bound);
+    SAFE_CUDA_FREE(state->constraint_lower_bound_finite_val);
+    SAFE_CUDA_FREE(state->constraint_upper_bound_finite_val);
+    SAFE_CUDA_FREE(state->variable_lower_bound_finite_val);
+    SAFE_CUDA_FREE(state->variable_upper_bound_finite_val);
+
+    SAFE_CUDA_FREE(state->initial_primal_solution);
+    SAFE_CUDA_FREE(state->current_primal_solution);
+    SAFE_CUDA_FREE(state->pdhg_primal_solution);
+    SAFE_CUDA_FREE(state->reflected_primal_solution);
+
+    SAFE_CUDA_FREE(state->dual_product);
+    SAFE_CUDA_FREE(state->initial_dual_solution);
+    SAFE_CUDA_FREE(state->current_dual_solution);
+    SAFE_CUDA_FREE(state->pdhg_dual_solution);
+    SAFE_CUDA_FREE(state->reflected_dual_solution);
+    SAFE_CUDA_FREE(state->primal_product);
+    
+    SAFE_CUDA_FREE(state->primal_slack);
+    SAFE_CUDA_FREE(state->dual_slack);
+    SAFE_CUDA_FREE(state->primal_residual);
+    SAFE_CUDA_FREE(state->dual_residual);
+    SAFE_CUDA_FREE(state->delta_primal_solution);
+    SAFE_CUDA_FREE(state->delta_dual_solution);
+    free(state);
+}
+
+static void perform_primal_restart(pdhg_solver_state_t *state)
+{
+    CUDA_CHECK(cudaMemcpy(state->initial_primal_solution, state->pdhg_primal_solution, state->num_variables * sizeof(double), cudaMemcpyDeviceToDevice));
+    CUDA_CHECK(cudaMemcpy(state->current_primal_solution, state->pdhg_primal_solution, state->num_variables * sizeof(double), cudaMemcpyDeviceToDevice));
+    state->inner_count = 0;
+    state->last_trial_fixed_point_error = INFINITY;
+}
+
+static void perform_dual_restart(pdhg_solver_state_t *state)
+{
+    CUDA_CHECK(cudaMemcpy(state->initial_dual_solution, state->pdhg_dual_solution, state->num_constraints * sizeof(double), cudaMemcpyDeviceToDevice));
+    CUDA_CHECK(cudaMemcpy(state->current_dual_solution, state->pdhg_dual_solution, state->num_constraints * sizeof(double), cudaMemcpyDeviceToDevice));
+    state->inner_count = 0;
+    state->last_trial_fixed_point_error = INFINITY;
+}
+
+__global__ void compute_delta_primal_solution_kernel(
+    const double *initial_primal, const double *pdhg_primal, double *delta_primal,
+    int n_vars)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n_vars)
+    {
+        delta_primal[i] = pdhg_primal[i] - initial_primal[i];
+    }
+}
+
+__global__ void compute_delta_dual_solution_kernel(
+    const double *initial_dual, const double *pdhg_dual, double *delta_dual,
+    int n_cons)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n_cons)
+    {
+        delta_dual[i] = pdhg_dual[i] - initial_dual[i];
+    }
+}
+
+static void compute_primal_fixed_point_error(pdhg_solver_state_t *state)
+{
+    compute_delta_primal_solution_kernel<<<state->num_blocks_primal, THREADS_PER_BLOCK>>>(
+        state->current_primal_solution,
+        state->reflected_primal_solution,
+        state->delta_primal_solution,
+        state->num_variables);
+    double primal_norm = 0.0;
+    CUBLAS_CHECK(cublasDnrm2_v2_64(state->blas_handle,
+                                   state->num_variables,
+                                   state->delta_primal_solution,
+                                   1,
+                                   &primal_norm));
+    state->fixed_point_error = primal_norm * primal_norm * state->primal_weight;
+}
+
+static void compute_dual_fixed_point_error(pdhg_solver_state_t *state)
+{
+    compute_delta_dual_solution_kernel<<<state->num_blocks_dual, THREADS_PER_BLOCK>>>(
+        state->current_dual_solution,
+        state->reflected_dual_solution,
+        state->delta_dual_solution,
+        state->num_constraints);
+    double dual_norm = 0.0;
+    CUBLAS_CHECK(cublasDnrm2_v2_64(state->blas_handle,
+                                   state->num_constraints,
+                                   state->delta_dual_solution,
+                                   1,
+                                   &dual_norm));
+    state->fixed_point_error = dual_norm * dual_norm / state->primal_weight;
+}
+
+


### PR DESCRIPTION
## Summary  
This PR introduces an optional **feasibility-polishing phase** that can be run after the normal PDHG solve.

### What is new  
- Two new command-line flags  
  `--feasibility_polishing`                    # enable the phase  
  `--eps_feas_polish <tol>`  # relative tolerance (default 1e-6)  

Two independent polishing loops
– Primal polish: solves a feasibility primal problem.
– Dual polish: solves an unconstrained dual feasibility problem.

If both primal polish and dual polish success, polished solutions will be saved.

### Implementation details  
- New solver states `primal_feas_polish_state_t` and `dual_feas_polish_state_t` that reuse the GPU buffers already allocated for the main solver.  
- New kernels `compute_primal_residual_kernel`, `compute_dual_residual_kernel`, `zero_finite_value_vectors_kernel` and helper functions `compute_primal_residual`, `compute_dual_residual`.  
- New termination reason `TERMINATION_REASON_FEAS_POLISH_SUCCESS`.  


### README
- Add new flags in the table of flags.
- Add a subsection to introduce this new feature.

### Benchmark
| Total Number | time > 3600 | SGM10 Time | SGM10 Iter | GeoMean Gap  | Gap > 1e-4 | GeoMean Pr Res | GeoMean Du Res
| ------------ | ----------- | ---------- | ---------- | ------------ | ---------- | ------------ | ---------- |
| 380          | 3           | 0.7        | 162.62     | 1.0773e-5| 110        |1.5603e-07 | 9.5639e-10 |

I run the default parameter (1e-4 for pdlp and 1e-6 for feasibility polishing) and record time usage and iteration count, shown in the table. The dataset I selected is from MIPLIB 383 instances, which is also used in the paper of PDLPx. 

### Log Example 
```
---------------------------------------------------------------------------------------
                                    cuPDLPx v0.1.2                                    
                        A GPU-Accelerated First-Order LP Solver                        
               (c) Haihao Lu, Massachusetts Institute of Technology, 2025              
---------------------------------------------------------------------------------------
problem:
  variables     : 200
  constraints   : 17013
  nnz(A)        : 104811
settings:
  iter_limit         : 2147483647
  time_limit         : 3600.00 sec
  eps_opt            : 1.0e-04
  eps_feas           : 1.0e-04
  eps_infeas_detect  : 1.0e-10
---------------------------------------------------------------------------------------
   runtime     |     objective      |   absolute residuals    |   relative residuals    
  iter   time  |  pr obj    du obj  |  pr res  du res   gap   |  pr res  du res   gap   
---------------------------------------------------------------------------------------
     0 4.6e-04 |  0.0e+00   0.0e+00 | 0.0e+00 1.4e+01 0.0e+00 | 0.0e+00 9.3e-01 0.0e+00 
    10 9.5e-04 | -1.8e+02  -4.3e+01 | 1.1e+01 1.0e+01 1.3e+02 | 8.5e-02 6.9e-01 6.1e-01 
 ......[More Entries]
  2900 1.1e-01 | -1.2e+02  -1.2e+02 | 1.2e-03 5.7e-04 1.4e-03 | 9.3e-06 3.8e-05 5.7e-06 
---------------------------------------------------------------------------------------
Solution Summary
  Status        : OPTIMAL
  Iterations    : 2900
  Solve time    : 0.109 sec
  Primal obj    : -121.220813
  Dual obj      : -121.2222111
  Primal infeas : 9.305e-06
  Dual infeas   : 3.776e-05
---------------------------------------------------------------------------------------
Starting Primal Feasibility Polishing Phase with relative tolerance 1.00e-06
---------------------------------------------------------------------------------------
  iter   time  |  pr obj  |  abs pr res  |  rel pr res  
---------------------------------------------------------------------------------------
     0 8.2e-05 | -1.2e+02 |    1.2e-03   |   9.3e-06   
    10 4.6e-04 | -1.2e+02 |    8.1e-04   |   6.2e-06   
    20 8.3e-04 | -1.2e+02 |    4.8e-04   |   3.6e-06   
    30 1.2e-03 | -1.2e+02 |    1.7e-04   |   1.3e-06   
    40 1.6e-03 | -1.2e+02 |    1.2e-05   |   9.4e-08   
---------------------------------------------------------------------------------------
Starting Dual Feasibility Polishing Phase with relative tolerance 1.00e-06
---------------------------------------------------------------------------------------
  iter   time  |  du obj  |  abs du res  |  rel du res  
---------------------------------------------------------------------------------------
     0 9.8e-05 | -1.2e+02 |    5.7e-04   |   3.8e-05   
    10 4.9e-04 | -1.2e+02 |    8.6e-16   |   5.7e-17   
---------------------------------------------------------------------------------------
Feasibility Polishing Summary
  Primal Status        : FEAS_POLISH_SUCCESS
  Primal Iterations    : 40
  Primal Time Usage    : 0.00157 sec
  Dual Status          : FEAS_POLISH_SUCCESS
  Dual Iterations      : 10
  Dual Time Usage      : 0.000493 sec
  Primal Residual      : 9.358e-08
  Dual Residual        : 5.681e-17
  Primal Dual Gap      : 3.078e-05
```