### PR TITLE
Refactor CMake build system with modular options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,20 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 # -----------------------------------------------------------------------------
 # CONTROL OPTIONS
 # -----------------------------------------------------------------------------
-# Option to control building the Python bindings (default is OFF for core/Julia builds)
-option(CUPDLPX_BUILD_PYTHON "Build the cuPDLPx Python bindings using pybind11" OFF)
+include(CMakeDependentOption)
+
+option(CUPDLPX_BUILD_STATIC_LIB "Build the cuPDLPx static library" ON)
+option(CUPDLPX_BUILD_SHARED_LIB "Build the cuPDLPx shared library" ON)
+
+# format: cmake_dependent_option(OPTION "docstring" DEFAULT_VALUE "DEPENDENCY_VARIABLE" FORCE_OFF_VALUE)
+cmake_dependent_option(CUPDLPX_BUILD_PYTHON "Build the cuPDLPx Python bindings" OFF
+                       "CUPDLPX_BUILD_STATIC_LIB" OFF)
+
+cmake_dependent_option(CUPDLPX_BUILD_CLI "Build the cuPDLPx command-line executable" ON
+                       "CUPDLPX_BUILD_STATIC_LIB" OFF)
+
+cmake_dependent_option(CUPDLPX_BUILD_TESTS "Build the cuPDLPx test suite" OFF
+                       "CUPDLPX_BUILD_STATIC_LIB" OFF)
 
 # -----------------------------------------------------------------------------
 # FIND DEPENDENCIES
@@ -130,103 +142,124 @@ set(CORE_LINK_LIBS PUBLIC
 # -----------------------------------------------------------------------------
 # 1. Core STATIC Library (cupdlpx_core)
 # -----------------------------------------------------------------------------
-add_library(cupdlpx_core STATIC
-  ${C_SOURCES}
-  ${CU_SOURCES}
-)
-target_include_directories(cupdlpx_core ${CORE_INCLUDE_DIRS})
-target_link_libraries(cupdlpx_core ${CORE_LINK_LIBS})
+if(CUPDLPX_BUILD_STATIC_LIB)
+    add_library(cupdlpx_core STATIC
+      ${C_SOURCES}
+      ${CU_SOURCES}
+    )
+    target_include_directories(cupdlpx_core ${CORE_INCLUDE_DIRS})
+    target_link_libraries(cupdlpx_core ${CORE_LINK_LIBS})
 
-set_target_properties(cupdlpx_core PROPERTIES
-  POSITION_INDEPENDENT_CODE ON
-  CUDA_SEPARABLE_COMPILATION ON
-  CUDA_RESOLVE_DEVICE_SYMBOLS ON
-)
+    set_target_properties(cupdlpx_core PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+      CUDA_SEPARABLE_COMPILATION ON
+      CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    )
+endif()
 
 # -----------------------------------------------------------------------------
 # 2. Shared Library (libcupdlpx.so)
 # -----------------------------------------------------------------------------
-add_library(cupdlpx_shared SHARED
-  ${C_SOURCES}
-  ${CU_SOURCES}
-)
-target_include_directories(cupdlpx_shared ${CORE_INCLUDE_DIRS})
-target_link_libraries(cupdlpx_shared ${CORE_LINK_LIBS})
+if(CUPDLPX_BUILD_SHARED_LIB)
+    add_library(cupdlpx_shared SHARED
+      ${C_SOURCES}
+      ${CU_SOURCES}
+    )
+    target_include_directories(cupdlpx_shared ${CORE_INCLUDE_DIRS})
+    target_link_libraries(cupdlpx_shared ${CORE_LINK_LIBS})
 
-# Shared library must resolve device symbols as it is a final link point
-set_target_properties(cupdlpx_shared PROPERTIES
-    OUTPUT_NAME "cupdlpx"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-    CUDA_SEPARABLE_COMPILATION ON
-    CUDA_RESOLVE_DEVICE_SYMBOLS ON
-)
+    # Shared library must resolve device symbols as it is a final link point
+    set_target_properties(cupdlpx_shared PROPERTIES
+        OUTPUT_NAME "cupdlpx"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        CUDA_SEPARABLE_COMPILATION ON
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    )
+endif()
 
 # -----------------------------------------------------------------------------
 # 3. CLI Executable (cupdlpx)
 # -----------------------------------------------------------------------------
-add_executable(cupdlpx_cli src/cli.c)
+if(CUPDLPX_BUILD_CLI)
+    if(NOT TARGET cupdlpx_core)
+        message(FATAL_ERROR "CUPDLPX_BUILD_CLI=ON requires CUPDLPX_BUILD_STATIC_LIB=ON.")
+    endif()
+    
+    add_executable(cupdlpx_cli src/cli.c)
 
-target_include_directories(cupdlpx_cli PRIVATE 
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/internal
-    ${CMAKE_CURRENT_BINARY_DIR}/generated
-)
+    target_include_directories(cupdlpx_cli PRIVATE 
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/internal
+        ${CMAKE_CURRENT_BINARY_DIR}/generated
+    )
 
-# Link CLI to the static core library
-target_link_libraries(cupdlpx_cli PRIVATE cupdlpx_core)
+    # Link CLI to the static core library
+    target_link_libraries(cupdlpx_cli PRIVATE cupdlpx_core)
 
-# CLI is a final executable, it must resolve device symbols
-set_target_properties(cupdlpx_cli PROPERTIES
-    OUTPUT_NAME "cupdlpx"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-    CUDA_RESOLVE_DEVICE_SYMBOLS ON
-)
+    # CLI is a final executable, it must resolve device symbols
+    set_target_properties(cupdlpx_cli PROPERTIES
+        OUTPUT_NAME "cupdlpx"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    )
+endif()
 
 # -----------------------------------------------------------------------------
 # 4. Tests (CTest Integration)
 # -----------------------------------------------------------------------------
-enable_testing()
-file(GLOB TEST_SOURCES
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/*.c"
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cu"
-)
+if(CUPDLPX_BUILD_TESTS)
+    if(NOT TARGET cupdlpx_core)
+        message(FATAL_ERROR "CUPDLPX_BUILD_TESTS=ON requires CUPDLPX_BUILD_STATIC_LIB=ON.")
+    endif()
 
-foreach(TEST_SRC ${TEST_SOURCES})
-    get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE) 
-    
-    add_executable(${TEST_NAME} ${TEST_SRC})
-    
-    # Link tests to the core static library
-    target_link_libraries(${TEST_NAME} PRIVATE cupdlpx_core)
+    enable_testing()
+    file(GLOB TEST_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/*.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cu"
+    )
 
-    # Set up test includes
-    target_include_directories(${TEST_NAME} 
-      PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-      PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/internal
-      PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated
-    )
-    
-    # Tests are final executables, they must resolve device symbols
-    set_target_properties(${TEST_NAME} PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tests"
-        CUDA_RESOLVE_DEVICE_SYMBOLS ON
-    )
-    
-    # Register with CTest
-    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-    
-endforeach()
+    foreach(TEST_SRC ${TEST_SOURCES})
+        get_filename_component(TEST_NAME ${TEST_SRC} NAME_WE) 
+        
+        add_executable(${TEST_NAME} ${TEST_SRC})
+        
+        # Link tests to the core static library
+        target_link_libraries(${TEST_NAME} PRIVATE cupdlpx_core)
+
+        # Set up test includes
+        target_include_directories(${TEST_NAME} 
+          PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+          PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/internal
+          PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/generated
+        )
+        
+        # Tests are final executables, they must resolve device symbols
+        set_target_properties(${TEST_NAME} PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/tests"
+            CUDA_RESOLVE_DEVICE_SYMBOLS ON
+        )
+        
+        # Register with CTest
+        add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+        
+    endforeach()
+endif()
 
 # -----------------------------------------------------------------------------
 # 5. Python Bindings (Conditional)
 # -----------------------------------------------------------------------------
 if (CUPDLPX_BUILD_PYTHON)
+    if(NOT TARGET cupdlpx_core)
+        message(FATAL_ERROR "CUPDLPX_BUILD_PYTHON=ON requires CUPDLPX_BUILD_STATIC_LIB=ON.")
+    endif()
+    
     add_subdirectory(python_bindings)
 endif()
 
 # -----------------------------------------------------------------------------
 # 6. Install Targets
 # -----------------------------------------------------------------------------
+
 if (CUPDLPX_BUILD_PYTHON)
     install(DIRECTORY include/
         DESTINATION include/
@@ -234,11 +267,25 @@ if (CUPDLPX_BUILD_PYTHON)
     )
 
 else()
-    install(TARGETS cupdlpx_core cupdlpx_shared cupdlpx_cli
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib
-        RUNTIME DESTINATION bin
-    )
+    if(TARGET cupdlpx_core)
+        install(TARGETS cupdlpx_core
+            ARCHIVE DESTINATION lib
+        )
+    endif()
+    
+    if(TARGET cupdlpx_shared)
+        install(TARGETS cupdlpx_shared
+            LIBRARY DESTINATION lib
+            RUNTIME DESTINATION bin # 'bin' for DLLs on Windows, 'lib' for .so on Linux
+        )
+    endif()
+    
+    if(TARGET cupdlpx_cli)
+        install(TARGETS cupdlpx_cli
+            RUNTIME DESTINATION bin
+        )
+    endif()
+
     install(DIRECTORY include/
         DESTINATION include/
         FILES_MATCHING PATTERN "*.h"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "cupdlpx"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python bindings for cuPDLPx (GPU-accelerated first-order LP solver)"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -28,6 +28,10 @@ sdist.include = ["tests/**", "pyproject.toml", "README.md", "LICENSE"]
 CMAKE_CUDA_ARCHITECTURES = "75;80;86;89;90;90-virtual"
 CMAKE_CUDA_STANDARD = "17"
 CUPDLPX_BUILD_PYTHON = "ON"
+CUPDLPX_BUILD_STATIC_LIB = "ON"
+CUPDLPX_BUILD_SHARED_LIB = "OFF"
+CUPDLPX_BUILD_CLI = "OFF"
+CUPDLPX_BUILD_TESTS = "OFF"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
#### Summary of Changes

This PR refactors the root `CMakeLists.txt` to introduce a set of modular build options, inspired by best practices seen in projects like `osqp`. This provides fine-grained control over which build artifacts are created.

The new key options are:
* `CUPDLPX_BUILD_STATIC_LIB` (Default: `ON`)
* `CUPDLPX_BUILD_SHARED_LIB` (Default: `ON`)
* `CUPDLPX_BUILD_CLI` (Default: `ON`, depends on `STATIC_LIB`)
* `CUPDLPX_BUILD_TESTS` (Default: `OFF`, depends on `STATIC_LIB`)
* `CUPDLPX_BUILD_PYTHON` (Default: `OFF`, depends on `STATIC_LIB`)

The `install` rules have also been updated to respect these new options.

#### Motivation for this Change

The previous build system built all targets (static lib, shared lib, CLI) at once, which is not ideal for different packaging ecosystems (Python vs. Julia).

* **Julia (Yggdrasil)** only needs the `libcupdlpx.so` shared library.
* **Python (Wheels)** only needs the `cupdlpx_core` static library for the `pybind11` module to link against.

These options allow us to create minimal, clean builds tailored for each packaging workflow.

#### Impact on Packaging

This PR updates the build configurations for both Julia and Python:

1.  **[Julia] `build_tarballs.jl` is updated:**
    Now explicitly passes `-DCUPDLPX_BUILD_SHARED_LIB=ON` and disables all other targets (`STATIC_LIB=OFF`, `CLI=OFF`, `TESTS=OFF`, `PYTHON=OFF`) to ensure only the shared library is built.

2.  **[Python] `pyproject.toml` is updated:**
    Now explicitly passes `-DCUPDLPX_BUILD_STATIC_LIB=ON` and `-DCUPDLPX_BUILD_PYTHON=ON`, while disabling all other targets (`SHARED_LIB=OFF`, `CLI=OFF`, `TESTS=OFF`). This ensures the Python wheel is built by statically linking the core library.

This makes the packaging workflows for different platforms cleaner, more robust, and more efficient.