### PR TITLE
Refactor CUDA architectures configuration and update requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,11 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# Increase compatibility by compiling for all supported real and virtual architectures.
-set(CMAKE_CUDA_ARCHITECTURES all)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.23")
+    set(CMAKE_CUDA_ARCHITECTURES all)
+else()
+    set(CMAKE_CUDA_ARCHITECTURES 60 61 70 75 80 86 89 90 90-virtual)
+endif()
 
 # Global Compile flags (corresponding to CFLAGS/NVCCFLAGS)
 add_compile_options(-fPIC -O3 -Wall -Wextra -g)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Our work is presented in two papers:
 
 ### Requirements
 * **GPU:** NVIDIA GPU with CUDA 12.4+.
-* **Build Tools:** CMake (≥ 3.22), GCC, NVCC.
+* **Build Tools:** CMake (≥ 3.20), GCC, NVCC.
 
 
 ### Build from Source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ wheel.packages = ["python/cupdlpx"]
 sdist.include = ["tests/**", "pyproject.toml", "README.md", "LICENSE"]
 
 [tool.scikit-build.cmake.define]
-CMAKE_CUDA_ARCHITECTURES = "75;80;86;89;90;90-virtual"
+CMAKE_CUDA_ARCHITECTURES = "60;61;70;75;80;86;89;90;90-virtual"
 CMAKE_CUDA_STANDARD = "17"
 CUPDLPX_BUILD_PYTHON = "ON"
 CUPDLPX_BUILD_STATIC_LIB = "ON"


### PR DESCRIPTION
This PR updates the build system to improve CUDA architecture targeting and corrects the documentation for build requirements.

### Changes

**1. CMake Configuration (`CMakeLists.txt`)**
* **Logic Update:** Introduced a check for `CMAKE_VERSION`.
* **CMake ≥ 3.23:** Now sets `CMAKE_CUDA_ARCHITECTURES` to `all`. This automatically targets all supported real and virtual architectures, simplifying future maintenance.
* **CMake < 3.23:** Added a manual fallback list (`60` through `90`) and explicitly added `90-virtual`. This ensures forward compatibility with future GPUs (via PTX JIT) when building with older CMake versions.

**2. Documentation (`README.md`)**
* **Requirements:** Updated the "Build Tools" section to specify `CMake (≥ 3.20)` instead of `3.22`, aligning the documentation with the actual project requirements.