### PR TITLE
Fix stepsize=0 bug when constraint matrix is empty

### DIFF
--- a/src/solver.cu
+++ b/src/solver.cu
@@ -761,14 +761,14 @@ initialize_step_size_and_primal_weight(pdhg_solver_state_t *state,
     if (state->constraint_matrix->num_nonzeros == 0)
     {
         state->step_size = 1.0;
-        state->primal_weight = 1.0;
-        state->best_primal_weight = 1.0;
-        return;
     }
-    double max_sv = estimate_maximum_singular_value(
-        state->sparse_handle, state->blas_handle, state->constraint_matrix,
-        state->constraint_matrix_t, params->sv_max_iter, params->sv_tol);
-    state->step_size = 0.998 / max_sv;
+    else
+    {
+        double max_sv = estimate_maximum_singular_value(
+            state->sparse_handle, state->blas_handle, state->constraint_matrix,
+            state->constraint_matrix_t, params->sv_max_iter, params->sv_tol);
+        state->step_size = 0.998 / max_sv;
+    }
 
     if (params->bound_objective_rescaling)
     {


### PR DESCRIPTION
## Fixes #49 
This might not be the best way to fix this issue. However, it worked for the failed example.
PSLP might be able to handle this instance during presolve. Related Issue: https://github.com/dance858/PSLP/issues/26

**Example**
```
NAME
ROWS
 N  OBJ
COLUMNS
    x         OBJ       -3
RHS
RANGES
BOUNDS
 MI bounds    x
 UP bounds    x         2
ENDATA
```


**Output**
```
$ ./build/cupdlpx test.mps test/ -v
---------------------------------------------------------------------------------------
                                    cuPDLPx v0.1.4                                    
                        A GPU-Accelerated First-Order LP Solver                        
               (c) Haihao Lu, Massachusetts Institute of Technology, 2025              
---------------------------------------------------------------------------------------
problem:
  variables     : 1
  constraints   : 0
  nonzeros(A)   : 0
settings:
  iter_limit         : 2147483647
  time_limit         : 3600.00 sec
  eps_opt            : 1.0e-04
  eps_feas           : 1.0e-04
  eps_infeas_detect  : 1.0e-10
---------------------------------------------------------------------------------------
   runtime     |     objective      |   absolute residuals    |   relative residuals    
  iter   time  |  pr obj    du obj  |  pr res  du res   gap   |  pr res  du res   gap   
---------------------------------------------------------------------------------------
     0 2.8e-03 |  0.0e+00   0.0e+00 | 0.0e+00 3.0e+00 0.0e+00 | 0.0e+00 7.5e-01 0.0e+00 
    10 3.0e-03 | -6.0e+00  -4.7e+00 | 0.0e+00 6.7e-01 1.3e+00 | 0.0e+00 1.7e-01 1.1e-01 
    20 3.2e-03 | -6.0e+00  -5.4e+00 | 0.0e+00 3.2e-01 6.3e-01 | 0.0e+00 7.9e-02 5.1e-02 
    30 3.3e-03 | -6.0e+00  -5.6e+00 | 0.0e+00 2.1e-01 4.1e-01 | 0.0e+00 5.2e-02 3.3e-02 
    40 3.4e-03 | -6.0e+00  -5.7e+00 | 0.0e+00 1.5e-01 3.1e-01 | 0.0e+00 3.8e-02 2.4e-02 
    50 3.5e-03 | -6.0e+00  -5.8e+00 | 0.0e+00 1.2e-01 2.4e-01 | 0.0e+00 3.1e-02 1.9e-02 
    60 3.7e-03 | -6.0e+00  -5.8e+00 | 0.0e+00 1.0e-01 2.0e-01 | 0.0e+00 2.5e-02 1.6e-02 
    70 3.8e-03 | -6.0e+00  -5.8e+00 | 0.0e+00 8.7e-02 1.7e-01 | 0.0e+00 2.2e-02 1.4e-02 
    80 3.9e-03 | -6.0e+00  -5.8e+00 | 0.0e+00 7.6e-02 1.5e-01 | 0.0e+00 1.9e-02 1.2e-02 
    90 4.1e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 6.7e-02 1.3e-01 | 0.0e+00 1.7e-02 1.0e-02 
   100 4.2e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 6.1e-02 1.2e-01 | 0.0e+00 1.5e-02 9.4e-03 
   110 4.3e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 5.5e-02 1.1e-01 | 0.0e+00 1.4e-02 8.5e-03 
   120 4.4e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 5.0e-02 1.0e-01 | 0.0e+00 1.3e-02 7.8e-03 
   130 4.6e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 4.7e-02 9.3e-02 | 0.0e+00 1.2e-02 7.2e-03 
   140 4.7e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 4.3e-02 8.6e-02 | 0.0e+00 1.1e-02 6.7e-03 
   150 4.8e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 4.0e-02 8.1e-02 | 0.0e+00 1.0e-02 6.2e-03 
   160 5.0e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 3.8e-02 7.5e-02 | 0.0e+00 9.4e-03 5.8e-03 
   170 5.1e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 3.6e-02 7.1e-02 | 0.0e+00 8.9e-03 5.5e-03 
   180 5.2e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 3.4e-02 6.7e-02 | 0.0e+00 8.4e-03 5.2e-03 
   190 5.3e-03 | -6.0e+00  -5.9e+00 | 0.0e+00 3.2e-02 6.3e-02 | 0.0e+00 7.9e-03 4.9e-03 
   200 6.1e-03 | -6.0e+00  -6.0e+00 | 0.0e+00 1.0e-02 2.0e-02 | 0.0e+00 2.5e-03 1.5e-03 
   210 6.3e-03 | -6.0e+00  -6.0e+00 | 0.0e+00 0.0e+00 0.0e+00 | 0.0e+00 0.0e+00 0.0e+00 
---------------------------------------------------------------------------------------
Solution Summary
  Status        : OPTIMAL
  Iterations    : 210
  Solve time    : 0.00634 sec
  Primal obj    : -6
  Dual obj      : -6
  Primal infeas : 0.000e+00
  Dual infeas   : 0.000e+00
```