### PR TITLE
Fix: primal obj value bug at postsolve

### DIFF
--- a/src/presolve.c
+++ b/src/presolve.c
@@ -184,7 +184,7 @@ void pslp_postsolve(cupdlpx_presolve_info_t *info,
     memcpy(result->primal_solution, info->presolver->sol->x, original_prob->num_variables * sizeof(double));
     memcpy(result->dual_solution, info->presolver->sol->y, original_prob->num_constraints * sizeof(double));
     memcpy(result->reduced_cost, info->presolver->sol->z, original_prob->num_variables * sizeof(double));
-    result->primal_objective_value = info->presolver->sol->obj;
+    // result->primal_objective_value = info->presolver->sol->obj; // This is a bug in PSLP. We don't need to updated primal_objective_value since offset has been updated during presolve. Therefore, the original problem and reduced problem have the same objective value.
     result->presolve_time = info->presolve_time;
     // if (info->presolver->stats != NULL) {
     //     result->presolve_stats = *(info->presolver->stats);


### PR DESCRIPTION
### Description
The `presolver->sol->obj` returned by **PSLP** is incorrect in `v0.0.3`.
We don't need to update `primal_objective_value` since `offset` in the reduced problem has been correctly calculated during presolve. Therefore, the original problem and reduced problem have the same objective value.

PSLP issue: https://github.com/dance858/PSLP/issues/29