### PR TITLE
Fix: CUDA out-of-bounds error in bound rescaling

### DIFF
--- a/src/preconditioner.cu
+++ b/src/preconditioner.cu
@@ -204,11 +204,7 @@ static void bound_objective_rescaling(pdhg_solver_state_t *state, rescale_info_t
     cublasGetPointerMode(state->blas_handle, &old_mode);
     cublasSetPointerMode(state->blas_handle, CUBLAS_POINTER_MODE_HOST);
 
-    CUBLAS_CHECK(cublasDasum(state->blas_handle, 
-                             num_constraints, 
-                             contrib_d, 
-                             1, 
-                             &bnd_norm_sq_h));
+    CUBLAS_CHECK(cublasDasum(state->blas_handle, num_constraints, contrib_d, 1, &bnd_norm_sq_h));
 
     cublasSetPointerMode(state->blas_handle, old_mode);
 

--- a/src/preconditioner.cu
+++ b/src/preconditioner.cu
@@ -198,19 +198,22 @@ static void bound_objective_rescaling(pdhg_solver_state_t *state, rescale_info_t
     compute_bound_contrib_kernel<<<state->num_blocks_dual, THREADS_PER_BLOCK>>>(
         state->constraint_lower_bound, state->constraint_upper_bound, num_constraints, contrib_d);
 
-    double *bnd_norm_sq_d = nullptr;
-    CUDA_CHECK(cudaMalloc(&bnd_norm_sq_d, sizeof(double)));
-    void *temp_storage = nullptr;
-    size_t temp_bytes = 0;
-    CUDA_CHECK(cub::DeviceReduce::Sum(temp_storage, temp_bytes, contrib_d, bnd_norm_sq_d, num_constraints));
-    CUDA_CHECK(cudaMalloc(&temp_storage, temp_bytes));
-    CUDA_CHECK(cub::DeviceReduce::Sum(temp_storage, temp_bytes, contrib_d, bnd_norm_sq_d, num_constraints));
-    CUDA_CHECK(cudaFree(contrib_d));
-    CUDA_CHECK(cudaFree(temp_storage));
-
     double bnd_norm_sq_h = 0.0;
-    CUDA_CHECK(cudaMemcpy(&bnd_norm_sq_h, bnd_norm_sq_d, sizeof(double), cudaMemcpyDeviceToHost));
-    CUDA_CHECK(cudaFree(bnd_norm_sq_d));
+
+    cublasPointerMode_t old_mode;
+    cublasGetPointerMode(state->blas_handle, &old_mode);
+    cublasSetPointerMode(state->blas_handle, CUBLAS_POINTER_MODE_HOST);
+
+    CUBLAS_CHECK(cublasDasum(state->blas_handle, 
+                             num_constraints, 
+                             contrib_d, 
+                             1, 
+                             &bnd_norm_sq_h));
+
+    cublasSetPointerMode(state->blas_handle, old_mode);
+
+    CUDA_CHECK(cudaFree(contrib_d));
+
     double bnd_norm = sqrt(bnd_norm_sq_h);
 
     double obj_norm = 0.0;


### PR DESCRIPTION
Fixed a `Warp Illegal Address` error during bound objective rescaling by replacing the unstable `cub::DeviceReduce::Sum` with `cublasDasum`.

Before 
```
---------------------------------------------------------------------------------------
                                    cuPDLPx v0.2.9                                    
                        A GPU-Accelerated First-Order LP Solver                        
               (c) Haihao Lu, Massachusetts Institute of Technology, 2025              
---------------------------------------------------------------------------------------
Problem: 22117 rows, 200787 columns, 20078717 nonzeros
Settings:
  iter_limit         : 2147483647
  time_limit         : 3600.00 sec
  eps_opt            : 1.0e-04
  eps_feas           : 1.0e-04
  spmv_backend       : cusparseSpMV (auto)
  feasibility_polishing : on

Running presolver (PSLP v0.0.8)...
  status          : REDUCED
  presolve time   : 12 sec
  reduced problem : 20669 rows, 13824 columns, 1378816 nonzeros

Preconditioning
  Ruiz scaling (10 iterations)
  Pock-Chambolle scaling (alpha=1.0000)
  Bound-objective scaling
CUDA Error at /home/sevan/postPDLP/src/preconditioner.cu:227: cudaErrorIllegalAddress
```
After
```
---------------------------------------------------------------------------------------
                                    cuPDLPx v0.2.9                                    
                        A GPU-Accelerated First-Order LP Solver                        
               (c) Haihao Lu, Massachusetts Institute of Technology, 2025              
---------------------------------------------------------------------------------------
Problem: 22117 rows, 200787 columns, 20078717 nonzeros
Settings:
  iter_limit         : 2147483647
  time_limit         : 3600.00 sec
  eps_opt            : 1.0e-04
  eps_feas           : 1.0e-04
  spmv_backend       : cusparseSpMV (auto)
  feasibility_polishing : on

Running presolver (PSLP v0.0.8)...
  status          : REDUCED
  presolve time   : 11.8 sec
  reduced problem : 20669 rows, 13824 columns, 1378816 nonzeros

Preconditioning
  Ruiz scaling (10 iterations)
  Pock-Chambolle scaling (alpha=1.0000)
  Bound-objective scaling
---------------------------------------------------------------------------------------
   runtime     |     objective      |   absolute residuals    |   relative residuals    
  iter   time  |  pr obj    du obj  |  pr res  du res   gap   |  pr res  du res   gap   
---------------------------------------------------------------------------------------
     0 0.0e+00 |  0.0e+00   0.0e+00 | 0.0e+00 0.0e+00 0.0e+00 | 0.0e+00 0.0e+00 0.0e+00 
   200 0.0e+00 | -2.9e+02  -2.8e+02 | 3.2e+00 2.5e-01 3.2e+00 | 8.3e-03 2.1e-03 5.6e-03 
   400 2.7e-02 | -2.8e+02  -2.8e+02 | 1.6e+00 9.0e-02 1.5e+00 | 4.1e-03 7.6e-04 2.6e-03 
   600 3.7e-02 | -2.8e+02  -2.8e+02 | 2.2e-01 3.3e-01 3.4e-01 | 5.6e-04 2.8e-03 6.0e-04 
   800 4.6e-02 | -2.8e+02  -2.8e+02 | 9.0e-02 1.7e-01 2.0e-01 | 2.3e-04 1.5e-03 3.5e-04 
  1000 5.5e-02 | -2.8e+02  -2.8e+02 | 1.4e-02 9.1e-02 3.9e-02 | 3.5e-05 7.7e-04 6.9e-05 
  1200 6.5e-02 | -2.8e+02  -2.8e+02 | 3.3e-03 8.7e-02 4.7e-02 | 8.5e-06 7.3e-04 8.2e-05 
  1400 7.4e-02 | -2.8e+02  -2.8e+02 | 5.3e-03 2.9e-02 1.2e-02 | 1.4e-05 2.4e-04 2.1e-05 
  1600 8.3e-02 | -2.8e+02  -2.8e+02 | 3.7e-03 4.1e-03 2.2e-04 | 9.4e-06 3.5e-05 3.9e-07 
---------------------------------------------------------------------------------------
Starting Primal Feasibility Polishing Phase with relative tolerance 1.00e-06
---------------------------------------------------------------------------------------
  iter   time  |  pr obj  |  abs pr res  |  rel pr res  
---------------------------------------------------------------------------------------
     0 1.6e-04 | -2.8e+02 |    3.7e-03   |   9.4e-06   
   200 4.3e-02 | -2.8e+02 |    1.0e-05   |   2.6e-08   
---------------------------------------------------------------------------------------
Starting Dual Feasibility Polishing Phase with relative tolerance 1.00e-06
---------------------------------------------------------------------------------------
  iter   time  |  du obj  |  abs du res  |  rel du res  
---------------------------------------------------------------------------------------
     0 1.9e-04 | -2.8e+02 |    4.1e-03   |   3.5e-05   
   200 2.2e-02 | -2.8e+02 |    1.5e-15   |   1.3e-17   
---------------------------------------------------------------------------------------
Feasibility Polishing Summary
  Primal Status        : FEAS_POLISH_SUCCESS
  Primal Iterations    : 200
  Primal Time Usage    : 0.0427 sec
  Dual Status          : FEAS_POLISH_SUCCESS
  Dual Iterations      : 200
  Dual Time Usage      : 0.0222 sec
  Primal Residual      : 2.597e-08
  Dual Residual        : 1.279e-17
  Primal Dual Gap      : 1.755e-05
---------------------------------------------------------------------------------------
Solution Summary
  Status                 : FEAS_POLISH_SUCCESS
  Presolve time          : 11.8 sec
  Precondition time      : 0.004079 sec
  Solve time             : 0.0222 sec
  Iterations             : 200
  Primal objective       : -282.9505931
  Dual objective         : -282.960541
  Objective gap          : 1.755e-05
  Primal infeas          : 2.597e-08
  Dual infeas            : 1.279e-17
```