### PR TITLE
Fix: guard against NULL reader when MPS file cannot be opened

### DIFF
--- a/src/mps_parser.c
+++ b/src/mps_parser.c
@@ -408,6 +408,7 @@ lp_problem_t *read_mps_file(const char *filename)
     if (!reader)
     {
         fprintf(stderr, "ERROR: Could not open file %s\n", filename);
+        return NULL;
     }
 
     namemap_init(&state.row_map, 1024);


### PR DESCRIPTION
Fixed a crash in `read_mps_file()` when the input MPS file cannot be opened.

Previously, if `fast_reader_open(filename)` returned `NULL`, the function printed an error and continued into the parsing loop, which later called `fast_reader_gets()` with a `NULL` reader, causing a solution on an empty problem.

The fix is simply to return `NULL` immediately after the open failure in `src/mps_parser.c`.
