### PR TITLE
Fix: MPS reader drops RHS/RANGES/BOUNDS entries without a set name

### DIFF
--- a/src/mps_parser.c
+++ b/src/mps_parser.c
@@ -796,10 +796,26 @@ static int parse_columns_section(MpsParserState *state, char **tokens, int n_tok
     return 0;
 }
 
+// The set-name field of RHS, RANGES and BOUNDS lines is optional (Netlib and
+// CUTEst/SIF files often omit it). If the first data field already names a
+// known row (or column, for BOUNDS), there is no set name; otherwise the
+// first field is the set name and is skipped.
+static bool is_known_row(const MpsParserState *state, const char *name)
+{
+    if (state->objective_row_name && strcmp(name, state->objective_row_name) == 0)
+        return true;
+    return namemap_get(&state->row_map, name) != -1;
+}
+
+static int row_data_start(const MpsParserState *state, char **tokens, int n_tokens)
+{
+    return (n_tokens > 0 && is_known_row(state, tokens[0])) ? 0 : 1;
+}
+
 static int parse_rhs_section(MpsParserState *state, char **tokens, int n_tokens)
 {
 
-    for (int i = 1; i + 1 < n_tokens; i += 2)
+    for (int i = row_data_start(state, tokens, n_tokens); i + 1 < n_tokens; i += 2)
     {
         const char *row_name = tokens[i];
         double value = atof(tokens[i + 1]);
@@ -832,7 +848,7 @@ static int parse_rhs_section(MpsParserState *state, char **tokens, int n_tokens)
 static int parse_ranges_section(MpsParserState *state, char **tokens, int n_tokens)
 {
 
-    for (int i = 1; i + 1 < n_tokens; i += 2)
+    for (int i = row_data_start(state, tokens, n_tokens); i + 1 < n_tokens; i += 2)
     {
         const char *row_name = tokens[i];
         double range_val = atof(tokens[i + 1]);
@@ -870,13 +886,17 @@ static int parse_ranges_section(MpsParserState *state, char **tokens, int n_toke
 
 static int parse_bounds_section(MpsParserState *state, char **tokens, int n_tokens)
 {
-    if (n_tokens < 3)
+    if (n_tokens < 2)
         return 0;
 
     const char *bound_type = tokens[0];
 
-    const char *col_name = tokens[2];
-    double value = (n_tokens > 3) ? atof(tokens[3]) : 0.0;
+    // "type [set_name] column [value]"
+    int col_pos = (namemap_get(&state->col_map, tokens[1]) != -1) ? 1 : 2;
+    if (col_pos >= n_tokens)
+        return 0;
+    const char *col_name = tokens[col_pos];
+    double value = (col_pos + 1 < n_tokens) ? atof(tokens[col_pos + 1]) : 0.0;
 
     int col_idx = namemap_get(&state->col_map, col_name);
     if (col_idx == -1)

--- a/test/test_read_mps.py
+++ b/test/test_read_mps.py
@@ -51,6 +51,32 @@ MPS_MAX = MPS_MIN.replace(
     "OBJSENSE\n    MAXIMIZE\nROWS\n",
 )
 
+# MPS_MIN plus a RANGES entry, explicit bounds and an objective constant,
+# with the optional set-name field omitted in every RHS / RANGES / BOUNDS
+# line (as in Netlib / CUTEst files such as BLEND, SIERRA, GFRD-PNC, DFL001).
+MPS_NAMELESS = """NAME          TESTLP
+ROWS
+ N  COST
+ E  R1
+ L  R2
+ L  R3
+COLUMNS
+    X1        COST      1.0   R1        1.0
+    X1        R3        3.0
+    X2        COST      1.0   R1        2.0
+    X2        R2        1.0   R3        2.0
+RHS
+              R1        5.0   R2        2.0
+              R3        8.0   COST     -1.5
+RANGES
+              R3        6.0
+BOUNDS
+ UP           X1        4.0
+ LO           X2        0.5
+ MI           X1
+ENDATA
+"""
+
 
 @pytest.fixture
 def mps_min_file(tmp_path):
@@ -128,6 +154,26 @@ def test_read_objsense_maximize(mps_max_file):
     model = cupdlpx.read(str(mps_max_file))
     _check_min_model_data(model)
     assert model.ModelSense == PDLP.MAXIMIZE
+
+
+def test_read_sections_without_set_name(tmp_path):
+    """
+    Entries without a set name must still reach the right rows/columns
+    (the reader used to drop the whole RHS section in this case).
+    """
+    path = tmp_path / "nameless.mps"
+    path.write_text(MPS_NAMELESS)
+    model = cupdlpx.read(str(path))
+    assert model.num_vars == 2
+    assert model.num_constrs == 3
+    assert np.allclose(model.c, [1.0, 1.0])
+    # RHS on the objective row is the negated objective constant
+    assert np.isclose(model.c0, 1.5)
+    # RHS and RANGES: R3 <= 8 with range 6 becomes 2 <= R3 <= 8
+    assert np.allclose(model.constr_lb, [5.0, -np.inf, 2.0])
+    assert np.allclose(model.constr_ub, [5.0, 2.0, 8.0])
+    assert np.allclose(model.lb, [-np.inf, 0.5])
+    assert np.allclose(model.ub, [4.0, np.inf])
 
 
 def test_read_missing_file_raises(tmp_path):


### PR DESCRIPTION
## Summary

The MPS reader assumed the first field of every `RHS` / `RANGES` / `BOUNDS` line is the set name. That field is optional, and Netlib/CUTEst files such as `BLEND`, `SIERRA`, `GFRD-PNC` and `DFL001` omit it. On these files the whole `RHS` section was
silently dropped, so the solver returned OPTIMAL with objective 0 and zero residuals.

The reader now checks whether the first field already names a known row (or column, for BOUNDS); if so there is no set name to skip.

## Test

```bash
$ ./build/cupdlpx test/BLEND.SIF test/
---------------------------------------------------------------------------------------
                                    cuPDLPx v0.3.0                                    
                        A GPU-Accelerated First-Order LP Solver                        
               (c) Haihao Lu, Massachusetts Institute of Technology, 2025              
---------------------------------------------------------------------------------------
Problem: 74 rows, 83 columns, 491 nonzeros
Settings:
  iter_limit         : 2147483647
  time_limit         : 3600.00 sec
  eps_opt            : 1.0e-04
  eps_feas           : 1.0e-04
  spmv_backend       : cusparseSpMVOp (auto)

Running presolver (PSLP v0.0.8)...
  status          : REDUCED
  presolve time   : 0.000679 sec
  reduced problem : 58 rows, 63 columns, 394 nonzeros

Preconditioning
  Geometric-mean scaling (12 iterations)
  Ruiz scaling (10 iterations)
  Pock-Chambolle scaling (alpha=1.0000)
  Bound-objective scaling
---------------------------------------------------------------------------------------
   runtime     |     objective      |   absolute residuals    |   relative residuals    
  iter   time  |  pr obj    du obj  |  pr res  du res   gap   |  pr res  du res   gap   
---------------------------------------------------------------------------------------
     0 0.0e+00 |  0.0e+00   0.0e+00 | 0.0e+00 0.0e+00 0.0e+00 | 0.0e+00 0.0e+00 0.0e+00 
   200 0.0e+00 | -2.1e+01   0.0e+00 | 9.2e-01 3.6e+00 2.1e+01 | 3.0e-02 2.3e-01 9.5e-01 
   400 8.3e-03 | -2.4e+01  -1.1e+01 | 4.4e-01 2.1e+00 1.4e+01 | 1.4e-02 1.3e-01 3.8e-01 
   600 1.1e-02 | -2.6e+01  -1.6e+01 | 7.5e-01 1.4e+00 1.0e+01 | 2.5e-02 9.0e-02 2.3e-01 
   800 1.3e-02 | -2.7e+01  -2.4e+01 | 1.1e+00 5.5e-01 2.9e+00 | 3.7e-02 3.6e-02 5.6e-02 
  1000 1.6e-02 | -3.2e+01  -2.8e+01 | 1.0e+00 2.6e-01 4.3e+00 | 3.4e-02 1.7e-02 7.0e-02 
  1200 1.8e-02 | -3.4e+01  -3.0e+01 | 9.7e-01 1.0e-01 3.9e+00 | 3.2e-02 6.5e-03 6.0e-02 
  1400 2.1e-02 | -3.1e+01  -3.0e+01 | 2.8e-01 9.3e-02 9.0e-01 | 9.3e-03 6.1e-03 1.5e-02 
  1600 2.3e-02 | -3.3e+01  -3.1e+01 | 3.3e-01 4.5e-02 2.7e+00 | 1.1e-02 2.9e-03 4.2e-02 
  1800 2.6e-02 | -3.1e+01  -3.1e+01 | 1.5e-02 4.4e-02 1.4e-01 | 5.0e-04 2.9e-03 2.2e-03 
  2000 2.8e-02 | -3.2e+01  -3.1e+01 | 1.3e-01 4.0e-02 1.2e+00 | 4.2e-03 2.6e-03 1.8e-02 
  2200 3.0e-02 | -3.2e+01  -3.1e+01 | 1.5e-01 1.3e-02 9.6e-01 | 5.0e-03 8.4e-04 1.5e-02 
  2400 3.3e-02 | -3.1e+01  -3.1e+01 | 5.7e-02 7.2e-03 7.1e-02 | 1.9e-03 4.7e-04 1.1e-03 
  2600 3.5e-02 | -3.1e+01  -3.1e+01 | 4.8e-02 6.4e-03 3.5e-01 | 1.6e-03 4.2e-04 5.6e-03 
  2800 3.7e-02 | -3.1e+01  -3.1e+01 | 2.4e-02 4.5e-03 7.2e-02 | 8.0e-04 2.9e-04 1.1e-03 
  3000 4.0e-02 | -3.1e+01  -3.1e+01 | 2.3e-02 2.2e-03 9.7e-02 | 7.4e-04 1.4e-04 1.6e-03 
  3200 4.2e-02 | -3.1e+01  -3.1e+01 | 6.8e-03 1.5e-03 5.3e-03 | 2.3e-04 9.9e-05 8.5e-05 
  3400 4.5e-02 | -3.1e+01  -3.1e+01 | 1.4e-02 8.1e-04 9.5e-02 | 4.8e-04 5.3e-05 1.5e-03 
  3600 4.7e-02 | -3.1e+01  -3.1e+01 | 1.1e-02 4.1e-05 8.2e-02 | 3.6e-04 2.7e-06 1.3e-03 
  3800 5.0e-02 | -3.1e+01  -3.1e+01 | 2.6e-04 2.3e-04 7.2e-04 | 8.7e-06 1.5e-05 1.2e-05 
---------------------------------------------------------------------------------------
Solution Summary
  Status                 : OPTIMAL
  Presolve time          : 0.000679 sec
  Precondition time      : 0.003345 sec
  Solve time             : 0.0521 sec
  Iterations             : 3800
  Primal objective       : -30.81058612
  Dual objective         : -30.80986236
  Objective gap          : 1.156e-05
  Primal infeas          : 8.746e-06
  Dual infeas            : 1.498e-05
```